### PR TITLE
Get rid of using AppleLanguages pref key

### DIFF
--- a/LanguageManager-iOS/Classes/LanguageManager.swift
+++ b/LanguageManager-iOS/Classes/LanguageManager.swift
@@ -66,6 +66,7 @@ public class LanguageManager {
             
             let defaultLanguage = UserDefaults.standard.string(forKey: DefaultsKeys.defaultLanguage)
             guard defaultLanguage == nil else {
+                setLanguage(language: currentLanguage)
                 return
             }
             
@@ -102,9 +103,6 @@ public class LanguageManager {
         UIView.appearance().semanticContentAttribute = semanticContentAttribute
         UITextField.appearance().semanticContentAttribute = semanticContentAttribute
         
-        // change app language
-        UserDefaults.standard.set([language.rawValue], forKey: "AppleLanguages")
-        UserDefaults.standard.synchronize()
         
         // set current language
         currentLanguage = language


### PR DESCRIPTION
Removed usage of AppleLanguages pref key following apple recommendation to not use it as its undocumented and for future proofing in case of changing its behavior.
Removing the key usage gives developers flexibility if they wanted to stop using the library and return to the apple intended behavior because the key was never touched.