### PR TITLE
Defaulting to deviceLanguage

### DIFF
--- a/LanguageManager-iOS/Classes/Constants/Languages.swift
+++ b/LanguageManager-iOS/Classes/Constants/Languages.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public enum Languages: String {
   case ar,en,nl,ja,ko,vi,ru,sv,fr,es,pt,it,de,da,fi,nb,tr,el,id,
-  ms,th,hi,hu,pl,cs,sk,uk,hr,ca,ro,he,ur,fa,ku,arc,sl,ml,am
+  ms,th,hi,hu,pl,cs,sk,uk,hr,ca,ro,he,ur,fa,ku,arc,sl,ml,am,mn
   case enGB = "en-GB"
   case enAU = "en-AU"
   case enCA = "en-CA"

--- a/LanguageManager-iOS/Classes/Helpers/Storage.swift
+++ b/LanguageManager-iOS/Classes/Helpers/Storage.swift
@@ -24,4 +24,9 @@ class Storage {
   func set(_ value: String, forKey: DefaultsKeys) {
     defaults.set(value, forKey: forKey.rawValue)
   }
+    
+  func clear() {
+    defaults.removeObject(forKey: DefaultsKeys.selectedLanguage.rawValue)
+    defaults.removeObject(forKey: DefaultsKeys.defaultLanguage.rawValue)
+  }
 }

--- a/LanguageManager-iOS/Classes/Main/LanguageManager.swift
+++ b/LanguageManager-iOS/Classes/Main/LanguageManager.swift
@@ -78,7 +78,6 @@ public class LanguageManager {
     set {
       // swizzle the awakeFromNib from nib and localize the text in the new awakeFromNib
       UIView.localize()
-
       let defaultLanguage = storage.string(forKey: .defaultLanguage)
       guard defaultLanguage == nil else {
         // If the default language has been set before,
@@ -127,6 +126,10 @@ public class LanguageManager {
   }
 
   // MARK: - Public Methods
+    
+  public func reset() {
+    storage.clear()
+  }
 
   ///
   /// Set the current language of the app

--- a/LanguageManager-iOS/Classes/Main/LanguageManager.swift
+++ b/LanguageManager-iOS/Classes/Main/LanguageManager.swift
@@ -54,7 +54,7 @@ public class LanguageManager {
   public private(set) var currentLanguage: Languages {
     get {
       guard let currentLang = storage.string(forKey: .selectedLanguage) else {
-        fatalError("Did you set the default language for the app?")
+        return .deviceLanguage
       }
       return Languages(rawValue: currentLang)!
     }
@@ -71,7 +71,7 @@ public class LanguageManager {
   public var defaultLanguage: Languages {
     get {
       guard let defaultLanguage = storage.string(forKey: .defaultLanguage) else {
-        fatalError("Did you set the default language for the app?")
+        return .deviceLanguage
       }
       return Languages(rawValue: defaultLanguage)!
     }


### PR DESCRIPTION
It may be safer to default to `deviceLanguage` than throw a fatal error when the current or default language is accessed before it's been set. As issues here have mentioned, the fatal error can be thrown even in cases where the default language is set in `didFinishLaunchingWithOptions`.