### PR TITLE
Expose essential tooling for objective-c

### DIFF
--- a/LanguageManager-iOS/Classes/Constants/Languages.swift
+++ b/LanguageManager-iOS/Classes/Constants/Languages.swift
@@ -4,23 +4,179 @@
 //
 //  Created by abedalkareem omreyh on 10/11/2020.
 //
-
 import Foundation
+@objc public enum Languages: Int, RawRepresentable {
+    case ar,en,nl,ja,ko,vi,ru,sv,fr,es,pt,it,de,da,fi,nb,tr,el,id,
+    ms,th,hi,hu,pl,cs,sk,uk,hr,ca,ro,he,ur,fa,ku,arc,sl,ml,am
+    case deviceLanguage
 
-public enum Languages: String {
-  case ar,en,nl,ja,ko,vi,ru,sv,fr,es,pt,it,de,da,fi,nb,tr,el,id,
-  ms,th,hi,hu,pl,cs,sk,uk,hr,ca,ro,he,ur,fa,ku,arc,sl,ml,am
-  case enGB = "en-GB"
-  case enAU = "en-AU"
-  case enCA = "en-CA"
-  case enIN = "en-IN"
-  case frCA = "fr-CA"
-  case esMX = "es-MX"
-  case ptBR = "pt-BR"
-  case zhHans = "zh-Hans"
-  case zhHant = "zh-Hant"
-  case zhHK = "zh-HK"
-  case es419 = "es-419"
-  case ptPT = "pt-PT"
-  case deviceLanguage
+    public typealias RawValue = String
+    public var rawValue: RawValue {
+        switch self {
+            case .ar:
+            return "ar"
+            case .en:
+            return "en"
+            case .nl:
+            return "nl"
+            case .ja:
+            return "ja"
+            case .ko:
+            return "ko"
+            case .vi:
+            return "vi"
+            case .ru:
+            return "ru"
+            case .sv:
+            return "sv"
+            case .fr:
+            return "fr"
+            case .es:
+            return "es"
+            case .pt:
+            return "pt"
+            case .it:
+            return "it"
+            case .de:
+            return "de"
+            case .da:
+            return "da"
+            case .fi:
+            return "fi"
+            case .nb:
+            return "nb"
+            case .tr:
+            return "tr"
+            case .el:
+            return "el"
+            case .id:
+            return "id"
+            case .ms:
+            return "ms"
+            case .th:
+            return "th"
+            case .hi:
+            return "hi"
+            case .hu:
+            return "hu"
+            case .pl:
+            return "pl"
+            case .cs:
+            return "cs"
+            case .sk:
+            return "sk"
+            case .uk:
+            return "uk"
+            case .hr:
+            return "hr"
+            case .ca:
+            return "ca"
+            case .ro:
+            return "ro"
+            case .he:
+            return "he"
+            case .ur:
+            return "ur"
+            case .fa:
+            return "fa"
+            case .ku:
+            return "ku"
+            case .arc:
+            return "arc"
+            case .sl:
+            return "sl"
+            case .ml:
+            return "ml"
+            case .am:
+            return "am"
+            case .deviceLanguage:
+            return "deviceLanguage"
+        }
+    }
+
+    public init?(rawValue: RawValue) {
+        switch rawValue {
+            case "ar":
+            self = .ar
+            case "en":
+            self = .en
+            case "nl":
+            self = .nl
+            case "ja":
+            self = .ja
+            case "ko":
+            self = .ko
+            case "vi":
+            self = .vi
+            case "ru":
+            self = .ru
+            case "sv":
+            self = .sv
+            case "fr":
+            self = .fr
+            case "es":
+            self = .es
+            case "pt":
+            self = .pt
+            case "it":
+            self = .it
+            case "de":
+            self = .de
+            case "da":
+            self = .da
+            case "fi":
+            self = .fi
+            case "nb":
+            self = .nb
+            case "tr":
+            self = .tr
+            case "el":
+            self = .el
+            case "id":
+            self = .id
+            case "ms":
+            self = .ms
+            case "th":
+            self = .th
+            case "hi":
+            self = .hi
+            case "hu":
+            self = .hu
+            case "pl":
+            self = .pl
+            case "cs":
+            self = .cs
+            case "sk":
+            self = .sk
+            case "uk":
+            self = .uk
+            case "hr":
+            self = .hr
+            case "ca":
+            self = .ca
+            case "ro":
+            self = .ro
+            case "he":
+            self = .he
+            case "ur":
+            self = .ur
+            case "fa":
+            self = .fa
+            case "ku":
+            self = .ku
+            case "arc":
+            self = .arc
+            case "sl":
+            self = .sl
+            case "ml":
+            self = .ml
+            case "am":
+            self = .am
+            case "deviceLanguage":
+            self = .deviceLanguage
+            default:
+            return nil
+        }
+    }
+
 }

--- a/LanguageManager-iOS/Classes/Main/LanguageManager.swift
+++ b/LanguageManager-iOS/Classes/Main/LanguageManager.swift
@@ -28,7 +28,7 @@
 
 import UIKit
 
-public class LanguageManager {
+public class LanguageManager: NSObject {
 
   public typealias Animation = ((UIView) -> Void)
   public typealias ViewControllerFactory = ((String?) -> UIViewController)
@@ -43,7 +43,7 @@ public class LanguageManager {
   ///
   /// The singleton LanguageManager instance.
   ///
-  public static let shared: LanguageManager = LanguageManager()
+  @objc public static let shared: LanguageManager = LanguageManager()
 
   ///
   /// Current app language.
@@ -143,7 +143,7 @@ public class LanguageManager {
   ///                        so you need to animate the view, move it out of the screen, change the alpha,
   ///                        or scale it down to zero.
   ///
-  public func setLanguage(language: Languages,
+  @objc public func setLanguage(language: Languages,
                           for windows: [WindowAndTitle]? = nil,
                           viewControllerFactory: ViewControllerFactory? = nil,
                           animation: Animation? = nil) {


### PR DESCRIPTION
Alsalaam Alykum @Abedalkareem,

I was trying to work on getting your lib used in NativeScript; a framework to write cross-platform applications using typescript. NativeScript can interact with Objective-C exposed Swift libs, this means I can, without knowing how to write code in Swift, add inheriting from `NSObject` to any class, and `@objc` decorator to any class member and easily get any Swift lib to play with NativeScript. Your lib is not conventional though, and I had little of time with, a) `Languages` enum, where I ended-up applying the method from [this SO answer](https://stackoverflow.com/a/38490781) to convert it to Objective-C exportable enum, however it meant that enum values with a dash are not possible to include(?), and b) getting `WindowAndTitle` argument of `setLanguage` method to become in shape for Objective-C where I failed completely.

I'm hoping we can work on this MR together to get `Languages` enum, and `LanguageManager.setLanguage` method to be exported for objc.

P.s.: Have you considered licensing your work as GPL?