### PR TITLE
Fix PrivacyInfo.xcprivacy Invalid Privacy Manifest

### DIFF
--- a/LanguageManager-iOS/PrivacyInfo.xcprivacy
+++ b/LanguageManager-iOS/PrivacyInfo.xcprivacy
@@ -5,10 +5,12 @@
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>
-			<key>NSPrivacyAccessedAPITypeReasons</key>
-			<string>Save the current user language</string>
 			<key>NSPrivacyAccessedAPIType</key>
 			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
 		</dict>
 	</array>
 	<key>NSPrivacyTracking</key>


### PR DESCRIPTION
Apple is giving now ITMS-91108: Invalid privacy manifest.
Fixing it by changing the NSPrivacyAccessedAPITypeReasons to be the official list afforded by Apple/XCode with type array, instead of the type string.